### PR TITLE
Fix readyState not present

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -135,8 +135,10 @@ var XHR = Ember.Object.extend(ProgressEventTarget, {
     var object = this;
     var target = this.get('target');
     target.onreadystatechange = function() {
-      var State = READY_STATES[target.readyState];
-      object.set('state', State.create({request: target}));
+      if(target.readyState){
+        var State = READY_STATES[target.readyState];
+        object.set('state', State.create({request: target}));
+      }
     };
   })
 });


### PR DESCRIPTION
Somehow, sometimes, readyState is not present on target and it fails to create a State.
