### PR TITLE
Resolve deprecations warnings

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -15,7 +15,7 @@ var ProgressEventTarget = Ember.Mixin.create(Ember.PromiseProxyMixin, {
     return deferred;
   }).readOnly(),
 
-  target: Ember.required(),
+  target: null, //required
 
   init: function() {
     this._super.apply(this, arguments);
@@ -115,9 +115,9 @@ var XHR = Ember.Object.extend(ProgressEventTarget, {
   readyState: Ember.computed.readOnly('state.readyState'),
 
   responseType: Ember.computed.alias('target.responseType'),
-  responseBinding: Ember.Binding.oneWay('state.response'),
-  responseTextBinding: Ember.Binding.oneWay('state.responseText'),
-  responseXMLBinding: Ember.Binding.oneWay('state.responseXML'),
+  responseBinding: Ember.computed.oneWay('state.response'),
+  responseTextBinding: Ember.computed.oneWay('state.responseText'),
+  responseXMLBinding: Ember.computed.oneWay('state.responseXML'),
 
   timeout: Ember.computed.alias('target.timeout'),
   upload: Ember.computed(function() {


### PR DESCRIPTION
When using ember-xhr in ember 1.13+ there are deprecation warnings when
the application loads. This change resolves those warnings by following
their suggested deprecation path in the warning text.
